### PR TITLE
Switch Azure OpenAI auth from API key to Entra ID

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,13 +27,18 @@
     pip install -r requirements.txt
     ```
 
-4. プロジェクトのルートディレクトリに `.env` ファイルを作成し、Azure OpenAIの認証情報を追加します:
+4. プロジェクトのルートディレクトリに `.env` ファイルを作成し、Azure OpenAIの設定を追加します:
     ```env
     AZURE_OPENAI_ENDPOINT=your_azure_openai_endpoint
-    AZURE_OPENAI_API_KEY=your_azure_openai_api_key
     MODEL_DEPLOYMENT_NAME=your_azure_openai_model
     ```
     ※動作検証にはgpt-4oを利用しました。
+
+5. 認証はEntra ID（キーレス）を使用します。`DefaultAzureCredential` でトークンを取得するため、事前にサインインしてください:
+    ```sh
+    az login
+    ```
+    サインインするIDには、対象のAzure OpenAIリソースに対して `Cognitive Services OpenAI User` ロールが必要です。
 
 ## 使用方法
 

--- a/README.md
+++ b/README.md
@@ -6,7 +6,8 @@
 
 - Python 3.7以上
 - pip (Pythonパッケージインストーラー)
-- Azure OpenAIアカウントとAPIキー、エンドポイント
+- Azure CLI（`az` コマンド。`az login` によるEntra ID認証に必要）
+- Azure OpenAIアカウントとエンドポイント
 
 ## セットアップ
 

--- a/openai_utils.py
+++ b/openai_utils.py
@@ -1,14 +1,20 @@
 from pydantic import BaseModel
 from openai import AzureOpenAI
+from azure.identity import DefaultAzureCredential, get_bearer_token_provider
 from dotenv import load_dotenv
 import os
 import tiktoken
 
 load_dotenv()
 
+token_provider = get_bearer_token_provider(
+    DefaultAzureCredential(),
+    "https://cognitiveservices.azure.com/.default"
+)
+
 azure_openai_client = AzureOpenAI(
     azure_endpoint=os.getenv("AZURE_OPENAI_ENDPOINT"),
-    api_key=os.getenv("AZURE_OPENAI_API_KEY"),
+    azure_ad_token_provider=token_provider,
     api_version="2024-12-01-preview"
 )
 

--- a/requirements.in
+++ b/requirements.in
@@ -3,5 +3,6 @@ beautifulsoup4
 python-dateutil
 python-dotenv
 openai
+azure-identity
 python-pptx
 tiktoken

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,6 @@
 annotated-types==0.7.0
 anyio==4.8.0
+azure-identity==1.25.3
 beautifulsoup4==4.12.3
 certifi==2024.12.14
 charset-normalizer==3.4.1


### PR DESCRIPTION
Switches Azure OpenAI authentication from a static API key to Entra ID (keyless).

- `openai_utils.py`: use `DefaultAzureCredential` + bearer token provider for `https://cognitiveservices.azure.com/.default` instead of `api_key`
- `requirements.in` / `requirements.txt`: add `azure-identity`
- `README.md`: document `az login` and the required `Cognitive Services OpenAI User` role; remove `AZURE_OPENAI_API_KEY` from `.env`

Closes #5