### PR TITLE
Clarify Azure update lifecycle labels

### DIFF
--- a/.github/skills/azure-update-powerpoint/SKILL.md
+++ b/.github/skills/azure-update-powerpoint/SKILL.md
@@ -60,3 +60,22 @@ category, leave the entry flagged rather than guessing.
 - Require the generated Markdown and PowerPoint files to be non-empty.
 - Verify that the PowerPoint slide count equals the number of non-empty
   Markdown sections separated by 50 equals signs.
+
+## Reference timing
+
+One observed run on 2026-07-21 used `gpt-5.6-sol` for 43 updates,
+including 13 status reviews:
+
+| Phase | Time |
+|---|---:|
+| Fetch | 15.2s |
+| Status scan | 11.0s |
+| Status research | 105.5s |
+| PowerPoint generation | 175.5s |
+| Validation | 32.8s |
+| Total | 5m 40s |
+
+This is a planning example, not a performance target. Generation time varies
+mainly with slide count and model latency; research time varies with the number
+and complexity of ambiguous statuses. Replace this example only when it is no
+longer representative. Do not accumulate run history here.

--- a/.github/skills/azure-update-powerpoint/SKILL.md
+++ b/.github/skills/azure-update-powerpoint/SKILL.md
@@ -63,17 +63,17 @@ category, leave the entry flagged rather than guessing.
 
 ## Reference timing
 
-One observed run on 2026-07-21 used `gpt-5.6-sol` for 43 updates,
+Two observed runs on 2026-07-21 used `gpt-5.6-sol` for 43 updates,
 including 13 status reviews:
 
-| Phase | Time |
+| Phase | Observed range |
 |---|---:|
-| Fetch | 15.2s |
-| Status scan | 11.0s |
-| Status research | 105.5s |
-| PowerPoint generation | 175.5s |
-| Validation | 32.8s |
-| Total | 5m 40s |
+| Fetch | 15.2–31.6s |
+| Status scan | 11.0–17.5s |
+| Status research | 100.2–105.5s |
+| PowerPoint generation | 175.5–209.9s |
+| Validation | 32.8–48.4s |
+| Total | 5m 40s–6m 47.5s |
 
 This is a planning example, not a performance target. Generation time varies
 mainly with slide count and model latency; research time varies with the number

--- a/.github/skills/azure-update-powerpoint/SKILL.md
+++ b/.github/skills/azure-update-powerpoint/SKILL.md
@@ -23,6 +23,25 @@ Advance it by one day only when the user explicitly requests no overlap.
 If no standard deck exists for the latest period, stop instead of inferring a
 baseline from another kind of artifact.
 
+## Resolve ambiguous statuses
+
+After fetching, search the generated Markdown for `<!-- status-review`.
+If none exists, continue to PowerPoint generation.
+
+For each flagged entry:
+
+1. Read its existing reference links first.
+2. If necessary, search official Microsoft documentation for explicit
+   lifecycle wording.
+3. Change `要確認` to one of `一般提供`, `パブリックプレビュー`,
+   `プライベートプレビュー`, `開発中`, `リタイアメント`, or
+   `その他の更新`.
+4. Add the official evidence URL under `参考リンク` if it is not already
+   present, then remove the `status-review` comment.
+
+Do not change unflagged categories. If official sources do not resolve the
+category, leave the entry flagged rather than guessing.
+
 ## Run reliably
 
 - Run the README workflow directly. Add diagnostic commands only after a

--- a/1_get_azure_update.py
+++ b/1_get_azure_update.py
@@ -2,7 +2,220 @@ import requests
 from bs4 import BeautifulSoup  
 from datetime import datetime, timezone  
 from dateutil import parser  
+import re
 import sys
+
+STATUS_LABELS = {
+    "launched": "一般提供",
+    "in preview": "パブリックプレビュー",
+    "in development": "開発中",
+}
+
+AVAILABILITY_LABELS = {
+    "general availability": "一般提供",
+    "preview": "パブリックプレビュー",
+    "public preview": "パブリックプレビュー",
+    "private preview": "プライベートプレビュー",
+    "retirement": "リタイアメント",
+}
+
+TITLE_PREFIX_LABELS = (
+    ("Generally Available", "一般提供"),
+    ("General Availability", "一般提供"),
+    ("Public Preview", "パブリックプレビュー"),
+    ("Private Preview", "プライベートプレビュー"),
+    ("In Development", "開発中"),
+    ("Retirement", "リタイアメント"),
+    ("Preview", "パブリックプレビュー"),
+    ("GA", "一般提供"),
+)
+
+EDITORIAL_PREFIXES = ("Announcing", "New")
+REVIEW_CATEGORY_LABEL = "要確認"
+PREVIEW_LABELS = {"パブリックプレビュー", "プライベートプレビュー"}
+
+
+def extract_title_signals(raw_title):
+    """タイトルを表示用本文、接頭辞、ライフサイクル区分に分ける。"""
+    title = raw_title.lstrip("\ufeff\u200b").strip()
+
+    for prefix, label in TITLE_PREFIX_LABELS:
+        match = re.match(rf"^{re.escape(prefix)}\s*:\s*", title, re.IGNORECASE)
+        if match:
+            return title[match.end():].strip(), prefix, label
+
+    for prefix in EDITORIAL_PREFIXES:
+        match = re.match(rf"^{re.escape(prefix)}\s*:\s*", title, re.IGNORECASE)
+        if match:
+            displayed_title = (
+                title if prefix == "Announcing" else title[match.end():].strip()
+            )
+            return displayed_title, prefix, None
+
+    return title, None, None
+
+
+def get_availability_signals(item):
+    rings = []
+    labels = []
+
+    for availability in item.get("availabilities") or []:
+        ring = (availability.get("ring") or "").strip()
+        if not ring:
+            continue
+
+        rings.append(ring)
+        label = AVAILABILITY_LABELS.get(ring.casefold())
+        if label and label not in labels:
+            labels.append(label)
+
+    return rings, labels
+
+
+def labels_are_compatible(title_label, status_label):
+    if title_label == status_label:
+        return True
+
+    return status_label == "パブリックプレビュー" and title_label in PREVIEW_LABELS
+
+
+def availability_supports_label(
+    label,
+    availability_labels,
+    include_private_preview=False,
+):
+    labels = set(availability_labels)
+    if label == "一般提供":
+        return "一般提供" in labels
+    if label == "パブリックプレビュー":
+        supported_preview_labels = {"パブリックプレビュー"}
+        if include_private_preview:
+            supported_preview_labels.add("プライベートプレビュー")
+        return (
+            bool(labels & supported_preview_labels)
+            and "一般提供" not in labels
+        )
+    if label == "プライベートプレビュー":
+        return (
+            "プライベートプレビュー" in labels
+            and "パブリックプレビュー" not in labels
+            and "一般提供" not in labels
+        )
+    if label == "開発中":
+        return "開発中" in labels
+    if label == "リタイアメント":
+        return "リタイアメント" in labels
+    return False
+
+
+def normalize_update_status(item):
+    """APIの複数シグナルから表示区分を決め、曖昧な場合は確認情報を返す。"""
+    title, title_prefix, title_label = extract_title_signals(
+        item.get("title", "")
+    )
+    raw_status = (item.get("status") or "").strip()
+    status_label = STATUS_LABELS.get(raw_status.casefold())
+    rings, availability_labels = get_availability_signals(item)
+    tags = item.get("tags") or []
+    tag_names = {tag.casefold() for tag in tags}
+
+    retirement_tag = "retirements" in tag_names
+    announcement_signal = (
+        (title_prefix or "").casefold() == "announcing"
+        or "announcement" in tag_names
+    )
+
+    category_label = None
+    candidate_label = None
+    review_reason = None
+
+    if title_label:
+        if status_label and not labels_are_compatible(
+            title_label, status_label
+        ):
+            candidate_label = title_label
+            review_reason = "title prefix and API status disagree"
+        elif availability_labels and not availability_supports_label(
+            title_label, availability_labels
+        ):
+            candidate_label = title_label
+            review_reason = "title prefix and availability disagree"
+        else:
+            category_label = title_label
+    elif announcement_signal:
+        if status_label and availability_supports_label(
+            status_label,
+            availability_labels,
+            include_private_preview=True,
+        ):
+            category_label = status_label
+            if (
+                status_label == "パブリックプレビュー"
+                and set(availability_labels) == {"プライベートプレビュー"}
+            ):
+                category_label = "プライベートプレビュー"
+        else:
+            candidate_label = status_label
+            review_reason = "announcement lifecycle is not corroborated"
+    elif status_label:
+        if availability_labels and not availability_supports_label(
+            status_label,
+            availability_labels,
+            include_private_preview=True,
+        ):
+            candidate_label = status_label
+            review_reason = "API status and availability disagree"
+        else:
+            category_label = status_label
+            if (
+                status_label == "パブリックプレビュー"
+                and set(availability_labels) == {"プライベートプレビュー"}
+            ):
+                category_label = "プライベートプレビュー"
+    elif len(availability_labels) == 1:
+        category_label = availability_labels[0]
+    elif retirement_tag:
+        category_label = "リタイアメント"
+    else:
+        review_reason = "no lifecycle category was found"
+
+    review = None
+    if review_reason:
+        review = {
+            "reason": review_reason,
+            "status": raw_status,
+            "title_prefix": title_prefix or "",
+            "availability": rings,
+            "tags": tags,
+            "id": str(item.get("id") or ""),
+            "candidate": candidate_label or "",
+        }
+
+    return {
+        "category": category_label or REVIEW_CATEGORY_LABEL,
+        "title": title,
+        "review": review,
+    }
+
+
+def format_status_review(review):
+    if not review:
+        return ""
+
+    availability = ", ".join(review["availability"]) or "(none)"
+    tags = ", ".join(review["tags"]) or "(none)"
+    return (
+        "<!-- status-review\n"
+        f"reason: {review['reason']}\n"
+        f"status: {review['status'] or '(none)'}\n"
+        f"title-prefix: {review['title_prefix'] or '(none)'}\n"
+        f"availability: {availability}\n"
+        f"tags: {tags}\n"
+        f"id: {review['id'] or '(none)'}\n"
+        f"candidate: {review['candidate'] or '(none)'}\n"
+        "-->\n"
+    )
+
 
 def fetch_update_items(base_url, headers, page_size, filter_date):
     """ページを順にたどり、フィルター日付より古い更新に到達するまで項目を返す。"""
@@ -57,15 +270,6 @@ def main():
         'Origin': 'https://www.microsoft.com'  
     }  
  
-    status_translations = {  
-        "Launched": "一般提供",  
-        "In preview": "パブリックプレビュー",  
-        "Retirement": "リタイアメント",  
-        "Private Preview": "プライベートプレビュー",  
-        "General Availability": "一般提供",  
-        "Public Preview": "パブリックプレビュー",  
-    }  
- 
     output_filename = f"azure_update_{filter_date_str}_{datetime.now().strftime('%Y%m%d')}.md"
     with open(output_filename, "w", encoding="utf-8") as f:  # ファイルを最初に開く
         for item in fetch_update_items(base_url, headers, page_size, filter_date):  
@@ -82,26 +286,12 @@ def main():
             else:  
                 date_str = "不明"  
      
-            # ステータスの抽出  
-            status = item.get("status", "")  
-            if not status:  
-                # ステータスがない場合は availabilities から取得  
-                if item.get("availabilities"):  
-                    status = item["availabilities"][0].get("ring", "")  
-     
-            # ステータスを日本語に翻訳  
-            status_jp = status_translations.get(status, status)  
-     
-            # タイトルから不要なプレフィックスを除去  
-            title = item.get("title", "").strip()  
-            prefixes = ["Generally Available:", "Public Preview:", "Private Preview:", "Retirement:", "GA:", "New:"]  
-            for prefix in prefixes:  
-                if title.startswith(prefix):  
-                    title = title[len(prefix):].strip()  
-                    break  # 最初のマッチで停止  
-     
-            # スライドタイトルの作成  
-            slide_title = f"# {status_jp}: {title}"  
+            status_resolution = normalize_update_status(item)
+            slide_title = (
+                f"# {status_resolution['category']}: "
+                f"{status_resolution['title']}"
+            )
+            status_review = format_status_review(status_resolution["review"])
      
             # 更新対象機能の抽出  
             products = item.get("products", [])  
@@ -119,7 +309,8 @@ def main():
                 reference_links.append(link['href'])  
      
             # スライドの内容を構築  
-            slide_content = f"""{slide_title}  
+            slide_content = f"""{slide_title}
+{status_review}
      
     ## 更新対象機能  
     {features_text}  

--- a/1_get_azure_update.py
+++ b/1_get_azure_update.py
@@ -47,10 +47,7 @@ def extract_title_signals(raw_title):
     for prefix in EDITORIAL_PREFIXES:
         match = re.match(rf"^{re.escape(prefix)}\s*:\s*", title, re.IGNORECASE)
         if match:
-            displayed_title = (
-                title if prefix == "Announcing" else title[match.end():].strip()
-            )
-            return displayed_title, prefix, None
+            return title[match.end():].strip(), prefix, None
 
     return title, None, None
 

--- a/2_make_jp_update_pptx.py
+++ b/2_make_jp_update_pptx.py
@@ -1,9 +1,7 @@
 import os  
+import re
 import sys  
 import time
-from openai import AzureOpenAI  
-from dotenv import load_dotenv, find_dotenv  
-_ = load_dotenv(find_dotenv())  
   
 from pydantic import BaseModel  
 from openai_utils import get_parsed_completion  
@@ -13,6 +11,39 @@ from pptx.util import Inches, Pt
 from pptx.dml.color import RGBColor  
 from pptx.enum.text import MSO_AUTO_SIZE  # 追加  
 from pptx.enum.text import PP_ALIGN
+
+STATUS_REVIEW_PATTERN = re.compile(
+    r"<!--\s*status-review\b.*?-->\s*",
+    re.DOTALL,
+)
+
+
+def strip_status_review_comments(slide_text):
+    return STATUS_REVIEW_PATTERN.sub("", slide_text)
+
+
+def prepare_slide_prompt(slide_text):
+    cleaned_slide = strip_status_review_comments(slide_text).strip()
+    lines = cleaned_slide.splitlines()
+    if not lines:
+        return "", ""
+
+    heading = lines[0].strip()
+    if heading.startswith("#"):
+        heading = heading.lstrip("#").strip()
+
+    category, separator, title = heading.partition(":")
+    if not separator:
+        return "", cleaned_slide
+
+    lines[0] = f"# {title.strip()}"
+    return category.strip(), "\n".join(lines).strip()
+
+
+def format_slide_title(category, translated_title):
+    if not category:
+        return translated_title
+    return f"{category}: {translated_title}"
   
 class UpdateInformation(BaseModel):  
     title: str  
@@ -84,7 +115,7 @@ def main():
 入力された情報はあるAzureの機能更新情報です。この情報を以下のルールで更新して指定されたキーのJSONを回答してください  
   
 # ルール  
-- title: タイトル(先頭行): なるべくそのままの表現で日本語に翻訳する  
+- title: 先頭行の機能名だけを、なるべくそのままの表現で日本語に翻訳する。ライフサイクル区分は追加しない
 - target: 更新対象機能 : 元の情報のまま  
 - date: 更新日付: 元の情報のまま  
 - description: 更新内容: 日本語で３行程度に要約する  
@@ -100,9 +131,9 @@ def main():
   
     start_time = time.time()
     for i, slide_text in enumerate(slides, 1):  
-        user_prompt = slide_text.strip()
+        category, user_prompt = prepare_slide_prompt(slide_text)
         print_progress(i, total_slides, start_time)
-        # OpenAI APIを呼び出して、情報を取得  
+        # Microsoft Foundryモデルを呼び出して、情報を取得
         event, input_token, output_token = callGPT(system_prompt, user_prompt)  
   
         # スライド作成  
@@ -125,7 +156,7 @@ def main():
         title_frame = title_box.text_frame  
         title_frame.word_wrap = True  
         p = title_frame.paragraphs[0]  
-        p.text = event.title  
+        p.text = format_slide_title(category, event.title)
         p.font.size = Pt(28)  
         p.font.bold = True  
         p.font.name = 'Meiryo UI'  # フォント設定  

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 - Python 3.7以上
 - pip (Pythonパッケージインストーラー)
 - Azure CLI（`az` コマンド。`az login` によるEntra ID認証に必要）
-- Azure OpenAIアカウントとエンドポイント
+- Microsoft Foundry リソースとモデルデプロイ
 
 ## セットアップ
 
@@ -28,18 +28,18 @@
     pip install -r requirements.txt
     ```
 
-4. プロジェクトのルートディレクトリに `.env` ファイルを作成し、Azure OpenAIの設定を追加します:
+4. プロジェクトのルートディレクトリに `.env` ファイルを作成し、Microsoft Foundryの設定を追加します:
     ```env
-    AZURE_OPENAI_ENDPOINT=your_azure_openai_endpoint
-    MODEL_DEPLOYMENT_NAME=your_azure_openai_model
+    AZURE_OPENAI_ENDPOINT=your_foundry_endpoint
+    MODEL_DEPLOYMENT_NAME=your_model_deployment
     ```
-    ※動作検証にはgpt-4oを利用しました。
+    `AZURE_OPENAI_ENDPOINT` は既存コードとの互換性のための環境変数名です。値には Microsoft Foundry のエンドポイントを指定します。
 
 5. 認証はEntra ID（キーレス）を使用します。`DefaultAzureCredential` でトークンを取得するため、事前にサインインしてください:
     ```sh
     az login
     ```
-    サインインするIDには、対象のAzure OpenAIリソースに対して `Cognitive Services OpenAI User` ロールが必要です。
+    サインインするIDには、対象のMicrosoft Foundryリソースでモデルを呼び出すための権限が必要です。
 
 ## 使用方法
 
@@ -52,11 +52,17 @@
 python 1_get_azure_update.py 2025-01-01
 ```
 
-このコマンドは、更新情報を含むMarkdownファイルを作成します。
+このコマンドは、更新情報を含むMarkdownファイルを作成します。タイトルの区分には `一般提供`、`パブリックプレビュー`、`プライベートプレビュー`、`開発中`、`リタイアメント` を使用します。
 
-### ステップ2: プレゼンテーションデッキの生成
+### ステップ2: ステータスの確認（必要な場合）
 
-`2_make_jp_update_pptx.py` スクリプトを実行して、取得した更新情報を生成AIをつかって処理し、PowerPoint形式のプレゼンテーションデッキを生成します。
+取得元のタイトル、APIステータス、提供段階が一致しない場合、Markdownには `<!-- status-review` コメントと `要確認` 区分が追加されます。
+
+このリポジトリの `azure-update-powerpoint` Agent Skill を利用すると、既存の参考リンクと公式Microsoftドキュメントを調査し、`一般提供`、`パブリックプレビュー`、`プライベートプレビュー`、`開発中`、`リタイアメント`、または `その他の更新` に更新できます。該当コメントがなければ、このステップは不要です。
+
+### ステップ3: プレゼンテーションデッキの生成
+
+`2_make_jp_update_pptx.py` スクリプトを実行して、取得した更新情報をMicrosoft Foundryのモデルで処理し、PowerPoint形式のプレゼンテーションデッキを生成します。タイトル本文のみを翻訳し、Markdownで確定した区分はそのまま使用します。
 
 ```sh
 python 2_make_jp_update_pptx.py

--- a/openai_utils.py
+++ b/openai_utils.py
@@ -12,7 +12,7 @@ token_provider = get_bearer_token_provider(
     "https://cognitiveservices.azure.com/.default"
 )
 
-azure_openai_client = AzureOpenAI(
+foundry_client = AzureOpenAI(
     azure_endpoint=os.getenv("AZURE_OPENAI_ENDPOINT"),
     azure_ad_token_provider=token_provider,
     api_version="2024-12-01-preview"
@@ -22,7 +22,7 @@ model_deployment_name = os.getenv("MODEL_DEPLOYMENT_NAME")
 
 def get_parsed_completion(messages: list[dict], response_format: BaseModel):
     """
-    Get parsed completion from Azure OpenAI.
+    Get parsed completion from the configured Microsoft Foundry model deployment.
 
     Args:
         messages (list[dict]): List of message dictionaries.
@@ -31,7 +31,7 @@ def get_parsed_completion(messages: list[dict], response_format: BaseModel):
     Returns:
         tuple: Parsed event, input token count, output token count.
     """
-    completion = azure_openai_client.beta.chat.completions.parse(
+    completion = foundry_client.beta.chat.completions.parse(
         model=model_deployment_name,
         messages=messages,
         response_format=response_format,

--- a/tests/test_status_handling.py
+++ b/tests/test_status_handling.py
@@ -1,0 +1,209 @@
+import importlib.util
+import os
+from pathlib import Path
+import sys
+import unittest
+
+
+ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT))
+
+
+def load_script(module_name, filename):
+    spec = importlib.util.spec_from_file_location(module_name, ROOT / filename)
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[module_name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+get_updates = load_script("get_azure_update", "1_get_azure_update.py")
+
+os.environ.setdefault(
+    "AZURE_OPENAI_ENDPOINT",
+    "https://example.services.ai.azure.com/",
+)
+os.environ.setdefault("MODEL_DEPLOYMENT_NAME", "test-deployment")
+make_pptx = load_script("make_jp_update_pptx", "2_make_jp_update_pptx.py")
+
+
+def make_item(title, status=None, rings=None, tags=None, item_id="123"):
+    return {
+        "id": item_id,
+        "title": title,
+        "status": status,
+        "availabilities": [{"ring": ring} for ring in (rings or [])],
+        "tags": tags or [],
+    }
+
+
+class NormalizeUpdateStatusTests(unittest.TestCase):
+    def test_status_resolution_cases(self):
+        cases = [
+            (
+                "consistent general availability",
+                make_item(
+                    "Generally Available: Feature",
+                    "Launched",
+                    ["General Availability"],
+                ),
+                "一般提供",
+                "Feature",
+                None,
+            ),
+            (
+                "preview prefix conflicts with launched status",
+                make_item("Public Preview: Feature", "Launched", ["Preview"]),
+                "要確認",
+                "Feature",
+                "title prefix and API status disagree",
+            ),
+            (
+                "preview prefix conflicts with GA availability",
+                make_item(
+                    "Public Preview: Feature",
+                    "In preview",
+                    ["General Availability"],
+                ),
+                "要確認",
+                "Feature",
+                "title prefix and availability disagree",
+            ),
+            (
+                "public preview prefix conflicts with private-only availability",
+                make_item(
+                    "Public Preview: Feature",
+                    "In preview",
+                    ["Private Preview"],
+                ),
+                "要確認",
+                "Feature",
+                "title prefix and availability disagree",
+            ),
+            (
+                "corroborated GA announcement",
+                make_item(
+                    "Announcing: Feature",
+                    "Launched",
+                    ["General Availability"],
+                    ["Announcement"],
+                ),
+                "一般提供",
+                "Announcing: Feature",
+                None,
+            ),
+            (
+                "announcement without lifecycle",
+                make_item(
+                    "Announcing: Feature",
+                    rings=["Effective"],
+                    tags=["Announcement"],
+                ),
+                "要確認",
+                "Announcing: Feature",
+                "announcement lifecycle is not corroborated",
+            ),
+            (
+                "private preview prefix",
+                make_item(
+                    "Private Preview: Feature",
+                    "In preview",
+                    ["Private Preview"],
+                ),
+                "プライベートプレビュー",
+                "Feature",
+                None,
+            ),
+            (
+                "private preview ring refines broad status",
+                make_item("Feature", "In preview", ["Private Preview"]),
+                "プライベートプレビュー",
+                "Feature",
+                None,
+            ),
+            (
+                "retirement ring",
+                make_item(
+                    "Feature retirement notice",
+                    rings=["Retirement"],
+                    tags=["Retirements"],
+                ),
+                "リタイアメント",
+                "Feature retirement notice",
+                None,
+            ),
+            (
+                "retirement tag does not override public preview",
+                make_item(
+                    "Public Preview: Feature",
+                    "In preview",
+                    ["Preview"],
+                    ["Retirements"],
+                ),
+                "パブリックプレビュー",
+                "Feature",
+                None,
+            ),
+            (
+                "retirement tag is fallback evidence",
+                make_item(
+                    "Feature retirement notice",
+                    tags=["Retirements"],
+                ),
+                "リタイアメント",
+                "Feature retirement notice",
+                None,
+            ),
+        ]
+
+        for name, item, category, title, review_reason in cases:
+            with self.subTest(name=name):
+                result = get_updates.normalize_update_status(item)
+                self.assertEqual(category, result["category"])
+                self.assertEqual(title, result["title"])
+                if review_reason:
+                    self.assertEqual(review_reason, result["review"]["reason"])
+                else:
+                    self.assertIsNone(result["review"])
+
+    def test_review_comment_contains_source_signals(self):
+        result = get_updates.normalize_update_status(
+            make_item(
+                "Announcing: Feature",
+                rings=["Effective"],
+                tags=["Announcement"],
+                item_id="567",
+            )
+        )
+
+        comment = get_updates.format_status_review(result["review"])
+        self.assertIn("<!-- status-review", comment)
+        self.assertIn("availability: Effective", comment)
+        self.assertIn("id: 567", comment)
+
+
+class PowerPointTitleTests(unittest.TestCase):
+    def test_category_is_removed_from_model_prompt_and_reattached(self):
+        slide_text = """# 一般提供: Announcing: Feature
+
+<!-- status-review
+reason: example
+-->
+
+## 更新対象機能
+Azure Example
+"""
+
+        category, prompt = make_pptx.prepare_slide_prompt(slide_text)
+
+        self.assertEqual("一般提供", category)
+        self.assertTrue(prompt.startswith("# Announcing: Feature"))
+        self.assertNotIn("status-review", prompt)
+        self.assertEqual(
+            "一般提供: 翻訳済み機能",
+            make_pptx.format_slide_title(category, "翻訳済み機能"),
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_status_handling.py
+++ b/tests/test_status_handling.py
@@ -89,7 +89,7 @@ class NormalizeUpdateStatusTests(unittest.TestCase):
                     ["Announcement"],
                 ),
                 "一般提供",
-                "Announcing: Feature",
+                "Feature",
                 None,
             ),
             (
@@ -100,7 +100,7 @@ class NormalizeUpdateStatusTests(unittest.TestCase):
                     tags=["Announcement"],
                 ),
                 "要確認",
-                "Announcing: Feature",
+                "Feature",
                 "announcement lifecycle is not corroborated",
             ),
             (
@@ -165,6 +165,15 @@ class NormalizeUpdateStatusTests(unittest.TestCase):
                     self.assertEqual(review_reason, result["review"]["reason"])
                 else:
                     self.assertIsNone(result["review"])
+
+    def test_announcing_prefix_is_removed_from_display_title(self):
+        title, prefix, label = get_updates.extract_title_signals(
+            "Announcing: Feature"
+        )
+
+        self.assertEqual("Feature", title)
+        self.assertEqual("Announcing", prefix)
+        self.assertIsNone(label)
 
     def test_review_comment_contains_source_signals(self):
         result = get_updates.normalize_update_status(


### PR DESCRIPTION
## Summary

- Normalize Azure Update lifecycle signals and mark ambiguous records for evidence-based review.
- Preserve the resolved lifecycle category when translating PowerPoint titles with Microsoft Foundry.
- Add the conditional GitHub Copilot review workflow and update repository documentation.
- Add focused unit coverage for status conflicts, announcements, retirements, and title formatting.

## Testing

- `python -m unittest discover -s tests -v`
- `python -m py_compile 1_get_azure_update.py 2_make_jp_update_pptx.py openai_utils.py tests/test_status_handling.py`
- Short-window live Azure Updates API fetch confirming conflict markers are emitted.

This is a draft for additional review and potential testing before squash merge.

Closes #11